### PR TITLE
Use version 0.13. Update build.sbt to cross compile.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,11 @@ import sbtrelease.ReleasePlugin._
 
 name := "scala-storm"
 
-// If you comment this out, SBT 0.10 will default to Scala 2.8.1
-scalaVersion := "2.9.1"
+scalaVersion := "2.9.2"
 
 organization := "com.github.velvia"
+
+crossScalaVersions := Seq("2.9.2", "2.10.3")
 
 // sbt defaults to <project>/src/test/{scala,java} unless we put this in
 unmanagedSourceDirectories in Test <<= Seq( baseDirectory( _ / "test" ) ).join
@@ -16,7 +17,7 @@ unmanagedSourceDirectories in Compile <<= Seq( baseDirectory( _ / "src" ) ).join
 resolvers ++= Seq("clojars" at "http://clojars.org/repo/",
                   "clojure-releases" at "http://build.clojure.org/releases")
 
-libraryDependencies += "storm" % "storm" % "0.8.1" % "provided" exclude("junit", "junit") 
+libraryDependencies += "storm" % "storm" % "0.8.1" % "provided" exclude("junit", "junit")
 
 // This is to prevent error [java.lang.OutOfMemoryError: PermGen space]
 javaOptions += "-XX:MaxPermSize=1g"
@@ -24,6 +25,14 @@ javaOptions += "-XX:MaxPermSize=1g"
 javaOptions += "-Xmx2g"
 
 scalacOptions += "-Yresolve-term-conflict:package"
+
+scalacOptions ++= {
+  if (scalaVersion.value.startsWith("2.10")) {
+    Seq("-feature", "-language:implicitConversions")
+  } else {
+    Seq()
+  }
+}
 
 // When doing sbt run, fork a separate process.  This is apparently needed by storm.
 fork := true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.1
+sbt.version=0.13.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,3 @@
-
-resolvers += Resolver.url("sbt-plugin-releases",
-  new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
-
-addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")


### PR DESCRIPTION
Change xsbt-gpg plugin to sbt-pgp plugin as the former is not
available with the current version of sbt.

Update build.sbt to update Scala 2.9 patch version and to
cross compile with versions 2.9.2 and 2.10.3.

I did not found any incompatibility so the project should cross compile 
properly.
The cross build and artifact publish should work with 

```
sbt +compile
sbt +publish
```
