### PR TITLE
make storm config accessible in spout

### DIFF
--- a/src/main/scala/storm/scala/dsl/StormBolt.scala
+++ b/src/main/scala/storm/scala/dsl/StormBolt.scala
@@ -8,6 +8,7 @@ import backtype.storm.tuple.{Fields, Tuple}
 import backtype.storm.task.OutputCollector
 import backtype.storm.task.TopologyContext
 import scala.language.implicitConversions
+import java.util.{Map => JMap}
 
 // The StormBolt class is an implementation of IRichBolt which
 // provides a Scala DSL for making Bolt development concise.
@@ -21,12 +22,12 @@ import scala.language.implicitConversions
 abstract class StormBolt(val streamToFields: collection.Map[String, List[String]])
     extends BaseRichBolt with SetupFunc with ShutdownFunc with BoltDsl {
     var _context: TopologyContext = _
-    var _conf: java.util.Map[_, _] = _
+    var _conf: JMap[_, _] = _
 
     // A constructor for the common case when you just want to output to the default stream
     def this(outputFields: List[String]) = { this(Map("default" -> outputFields)) }
 
-    def prepare(conf:java.util.Map[_, _], context:TopologyContext, collector:OutputCollector) {
+    def prepare(conf:JMap[_, _], context:TopologyContext, collector:OutputCollector) {
         _collector = collector
         _context = context
         _conf = conf

--- a/src/main/scala/storm/scala/dsl/StormSpout.scala
+++ b/src/main/scala/storm/scala/dsl/StormSpout.scala
@@ -2,7 +2,6 @@
 
 package storm.scala.dsl
 
-import java.util.Map
 import backtype.storm.task.TopologyContext
 import backtype.storm.spout.SpoutOutputCollector
 import backtype.storm.topology.OutputFieldsDeclarer
@@ -15,13 +14,15 @@ abstract class StormSpout(val streamToFields: collection.Map[String, List[String
                           val isDistributed: Boolean) extends BaseRichSpout with SetupFunc with ShutdownFunc {
   var _context:TopologyContext = _
   var _collector:SpoutOutputCollector = _
+  var _conf: java.util.Map[_, _] = _
 
   // A constructor for the common case when you just want to output to the default stream
   def this(outputFields: List[String], distributed: Boolean = false) = this(collection.Map("default" -> outputFields), distributed)
 
-  def open(conf: Map[_, _], context: TopologyContext, collector: SpoutOutputCollector) = {
+  def open(conf: java.util.Map[_, _], context: TopologyContext, collector: SpoutOutputCollector) = {
     _context = context
     _collector = collector
+    _conf = conf
     _setup()
   }
 

--- a/src/main/scala/storm/scala/dsl/StormSpout.scala
+++ b/src/main/scala/storm/scala/dsl/StormSpout.scala
@@ -9,17 +9,18 @@ import backtype.storm.topology.base.BaseRichSpout
 import backtype.storm.tuple.Fields
 import collection.JavaConverters._
 import collection.JavaConversions._
+import java.util.{Map => JMap}
 
 abstract class StormSpout(val streamToFields: collection.Map[String, List[String]],
                           val isDistributed: Boolean) extends BaseRichSpout with SetupFunc with ShutdownFunc {
   var _context:TopologyContext = _
   var _collector:SpoutOutputCollector = _
-  var _conf: java.util.Map[_, _] = _
+  var _conf: JMap[_, _] = _
 
   // A constructor for the common case when you just want to output to the default stream
   def this(outputFields: List[String], distributed: Boolean = false) = this(collection.Map("default" -> outputFields), distributed)
 
-  def open(conf: java.util.Map[_, _], context: TopologyContext, collector: SpoutOutputCollector) = {
+  def open(conf: JMap[_, _], context: TopologyContext, collector: SpoutOutputCollector) = {
     _context = context
     _collector = collector
     _conf = conf

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 
-version in ThisBuild := "0.2.4-SNAPSHOT"
+version in ThisBuild := "0.2.5-SNAPSHOT"


### PR DESCRIPTION
Small update to be able to access the storm configuration from within the spout 'setup' functions.